### PR TITLE
Fixed recognition glitch in practice screen, and a crash

### DIFF
--- a/app/src/main/java/com/nui/handwritingcalculator/HandwritingView.java
+++ b/app/src/main/java/com/nui/handwritingcalculator/HandwritingView.java
@@ -43,6 +43,7 @@ public class HandwritingView extends View implements GestureOverlayView.OnGestur
     ArrayList<String> gString = new ArrayList<>();  //recognized gestures in a string
     Stack<CustomGesture> gestureStack = new Stack<CustomGesture>();
     CountDownTimer currentCountDownTimer;
+    public boolean isCurrentCountDownTimerRunning = false;
     public Boolean libraryLoaded = false;
     private Boolean gestureResetsText=false;
 
@@ -137,6 +138,7 @@ public class HandwritingView extends View implements GestureOverlayView.OnGestur
             //new (overlapping) gesture will only be added as part of the prev gesture which it overlaps
 
             currentCountDownTimer.cancel();
+            isCurrentCountDownTimerRunning = false;
 
             if (doGesturesOverlap(newGesture.gesture, lastGesture.gesture)) {
 //                System.out.println("Do overlap");
@@ -181,11 +183,11 @@ public class HandwritingView extends View implements GestureOverlayView.OnGestur
 //                System.out.println("time expired: recognize gesture");
                 recognizeGesture(gesture);
                 lastGesture = null;
-
+                isCurrentCountDownTimerRunning = false;
             }
         }.start();
 //        System.out.println("start Timer");
-
+        isCurrentCountDownTimerRunning = true;
         return countDownTimer;
     }
 
@@ -249,6 +251,13 @@ public class HandwritingView extends View implements GestureOverlayView.OnGestur
                 //Undo invlaid gesture
                 //keepGestureOnScreen(gesture,true);
             }
+        }
+    }
+
+    public void finalizeGesture() {
+        if (isCurrentCountDownTimerRunning == true) {
+            currentCountDownTimer.onFinish();
+            currentCountDownTimer.cancel();
         }
     }
 

--- a/app/src/main/java/com/nui/handwritingcalculator/PracticeActivity.java
+++ b/app/src/main/java/com/nui/handwritingcalculator/PracticeActivity.java
@@ -178,8 +178,7 @@ public class PracticeActivity extends AppCompatActivity {
     //--------------------*/
     private void checkAnswer() {
         //Finalizes the last gesture instantly
-        hwView.currentCountDownTimer.onFinish();
-        hwView.currentCountDownTimer.cancel();
+        hwView.finalizeGesture();
 
         //send formula for processing then write string to solutionView
         Double answer = getAnswer();
@@ -187,16 +186,25 @@ public class PracticeActivity extends AppCompatActivity {
 
         String userString = hwView.getTextString();
         Double userAnswer = (Double) 0.0;
+        boolean validNumber = true;
         if (userString != "") {
-            userAnswer = Double.valueOf(userString);
+            try {
+                userAnswer = Double.valueOf(userString);
+            }
+            catch (Exception e) {
+                validNumber = false;
+            }
         }
         //Should probably show some kind of popup here
 
-        if (userAnswer == answer) {
+        if (validNumber && userAnswer == answer) {
             Toast.makeText(this, "Your answer of " + userString + " is correct!", Toast.LENGTH_SHORT).show();
-        } else {
+        }
+        else if (validNumber && userAnswer != answer) {
             Toast.makeText(this, "Your answer of " + userString + " is not correct!", Toast.LENGTH_SHORT).show();
-
+        }
+        else if (validNumber == false) {
+            Toast.makeText(this, "Your answer of " + userString + " contains invalid symbols (numbers only)!", Toast.LENGTH_SHORT).show();
         }
         clear();
 


### PR DESCRIPTION
Recognition glitch caused by last gesture being recognized too late due to timer. Fixed a bug introdcued by a "fix" I previously made.

Additionally, fixed a crash caused by symbols that aren't integers (such as parentheses or operators) being cast to type Double